### PR TITLE
Added support for HDSPe MADI FX with new (?) vendor id

### DIFF
--- a/madifx.c
+++ b/madifx.c
@@ -305,7 +305,8 @@ enum {
 #define INPUT_DMA_BUFFER_SIZE (NUM_INPUTS_S_MFXT*32768)
 #define OUTPUT_DMA_BUFFER_SIZE (NUM_OUTPUTS_S_MFXT*32768)
 
-
+/* PCI Vendor id for HDSPe MADI FX (not found in linux headers) */
+#define PCI_VENDOR_ID_RME_MADI_FX 0x1d18
 
 /* names for speed modes */
 static char *madifx_speed_names[] = { "single", "double", "quad" };
@@ -442,6 +443,14 @@ struct mfx {
 static const struct pci_device_id snd_madifx_ids[] = {
 	{
 	 .vendor = PCI_VENDOR_ID_XILINX,
+	 .device = 0x3fc7,
+	 .subvendor = PCI_ANY_ID,
+	 .subdevice = PCI_ANY_ID,
+	 .class = 0,
+	 .class_mask = 0,
+	 .driver_data = 0},
+	 {
+	 .vendor = PCI_VENDOR_ID_RME_MADI_FX,
 	 .device = 0x3fc7,
 	 .subvendor = PCI_ANY_ID,
 	 .subdevice = PCI_ANY_ID,


### PR DESCRIPTION
Hello,
This PR adds support for the HDSPe MADI FX Triple MADI Card (or maybe just the specific card we have?).

The Card in our possession uses a different PCI vendor id then the one used in this driver.
The vendor id in question (`0x1d18`) is not defined in the `pci_ids.h` (linux kernel 6.1.80), so i have defined it in the file `madifx.c`.

I did some minimal testing (checking that audio comes out and in on some channels by connecting an input of the card to an output) 

In a couple of days i will be able to find out if more MADI FX Cards use this new vendor id.

Kind Regards