### PR TITLE
Make compile with kernels >= 6.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains a Linux kernel driver for RME MADI FX cards. It is
 still work in progress. Once finished, it'll be submitted to the mainline
 kernel.
 
+**Attention**: The driver only works with the _Legacy_ firmware (to date 219)
+and not the _DriverKit_ one (to date 220).
+
 **Until then, everything may change at any time, so don't expect the userpsace
 API to be stable.**
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This repository contains a Linux kernel driver for RME MADI FX cards. It is
 still work in progress. Once finished, it'll be submitted to the mainline
 kernel.
 
-**Attention**: The driver only works with the _Legacy_ firmware (to date 219)
-and not the _DriverKit_ one (to date 220).
-
 **Until then, everything may change at any time, so don't expect the userpsace
 API to be stable.**
 

--- a/madifx.c
+++ b/madifx.c
@@ -2341,7 +2341,7 @@ static int snd_madifx_hw_params(struct snd_pcm_substream *substream,
 
 		mfx->playback_buffer =
 			(unsigned char *) substream->runtime->dma_area;
-		snd_printdd("Allocated sample buffer for playback at %p\n",
+		pr_debug("Allocated sample buffer for playback at %p\n",
 				mfx->playback_buffer);
 	} else {
 		/* initialise default DMA table. Will be
@@ -2378,7 +2378,7 @@ static int snd_madifx_hw_params(struct snd_pcm_substream *substream,
 
 		mfx->capture_buffer =
 			(unsigned char *) substream->runtime->dma_area;
-		snd_printdd("Allocated sample buffer for capture at %p\n",
+		pr_debug("Allocated sample buffer for capture at %p\n",
 				mfx->capture_buffer);
 	}
 
@@ -3264,13 +3264,13 @@ static int snd_madifx_preallocate_memory(struct mfx *mfx)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0) && !defined(RH_NEW_AUDIO_STACK)
 	if (err < 0) {
-		snd_printdd("Could not preallocate %zd Bytes\n", wanted);
+		pr_debug("Could not preallocate %zd Bytes\n", wanted);
 
 		return err;
 	}
 #endif
 
-	snd_printdd(" Preallocated %zd Bytes\n", wanted);
+	pr_debug(" Preallocated %zd Bytes\n", wanted);
 
 
 #ifdef CONFIG_SND_MADIFX_BROKEN
@@ -3352,7 +3352,7 @@ static int snd_madifx_create_alsa_devices(struct snd_card *card,
 {
 	int err, i;
 
-	snd_printdd("Create card...\n");
+	pr_debug("Create card...\n");
 	err = snd_madifx_create_pcm(card, mfx);
 	if (err < 0)
 		return err;
@@ -3373,7 +3373,7 @@ static int snd_madifx_create_alsa_devices(struct snd_card *card,
 	if (err < 0)
 		return err;
 
-	snd_printdd("proc init...\n");
+	pr_debug("proc init...\n");
 	snd_madifx_proc_init(mfx);
 
 	mfx->system_sample_rate = -1;
@@ -3384,18 +3384,18 @@ static int snd_madifx_create_alsa_devices(struct snd_card *card,
 	mfx->capture_substream = NULL;
 	mfx->playback_substream = NULL;
 
-	snd_printdd("Set defaults...\n");
+	pr_debug("Set defaults...\n");
 	err = snd_madifx_set_defaults(mfx);
 	if (err < 0)
 		return err;
 
-	snd_printdd("Update mixer controls...\n");
+	pr_debug("Update mixer controls...\n");
 #if 0
 	/* FIXME: MADI FX disable, old mixer is broken */
 	madifx_update_simple_mixer_controls(mfx);
 #endif
 
-	snd_printdd("Initializeing complete ???\n");
+	pr_debug("Initializeing complete ???\n");
 
 	err = snd_card_register(card);
 	if (err < 0) {
@@ -3404,7 +3404,7 @@ static int snd_madifx_create_alsa_devices(struct snd_card *card,
 		return err;
 	}
 
-	snd_printdd("... yes now\n");
+	pr_debug("... yes now\n");
 
 	return 0;
 }
@@ -3457,7 +3457,7 @@ static int snd_madifx_create(struct snd_card *card,
 	io_extent = pci_resource_len(pci, 0);
 
 	mfx->iobase = pcim_iomap_table(pci)[0];
-	snd_printdd("remapped region (0x%lx) 0x%lx-0x%lx\n",
+	pr_debug("remapped region (0x%lx) 0x%lx-0x%lx\n",
 			(unsigned long)mfx->iobase, mfx->port,
 			mfx->port + io_extent - 1);
 
@@ -3468,11 +3468,11 @@ static int snd_madifx_create(struct snd_card *card,
 		return -EBUSY;
 	}
 
-	snd_printdd("use IRQ %d\n", pci->irq);
+	pr_debug("use IRQ %d\n", pci->irq);
 
 	mfx->irq = pci->irq;
 
-	snd_printdd("kmalloc Mixer memory of %zd Bytes\n",
+	pr_debug("kmalloc Mixer memory of %zd Bytes\n",
 			sizeof(*mfx->newmixer));
 
 	mfx->newmixer = devm_kzalloc(&pci->dev, sizeof(*mfx->newmixer), GFP_KERNEL);
@@ -3552,7 +3552,7 @@ static int snd_madifx_create(struct snd_card *card,
 	snprintf(card->id, sizeof(card->id), "MADIFXtest");
 	snd_card_set_id(card, card->id);
 
-	snd_printdd("create alsa devices.\n");
+	pr_debug("create alsa devices.\n");
 	err = snd_madifx_create_alsa_devices(card, mfx);
 	if (err < 0)
 		return err;

--- a/madifx.c
+++ b/madifx.c
@@ -45,6 +45,11 @@
 #include <sound/hwdep.h>
 #include <sound/initval.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+	#define from_timer timer_container_of
+	#define del_timer  timer_delete
+#endif
+
 #include "madifx.h"
 
 static int index[SNDRV_CARDS] = SNDRV_DEFAULT_IDX; /* Index 0-MAX */


### PR DESCRIPTION
@adiknoth Please excuse the mess in my madifx fork. I didn't figure out how to correctly sync with your (original) repo. So please ignore anything that's already upstream.

THis pull request is for kernels >= 6.16 where the kerenel functions  from_timer and del_timer have been replaced by timer_container_of and timer_delete.