### PR TITLE
Add dkms.conf for automatic building of module

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="alsa-madifx"
+PACKAGE_VERSION="0.0"
+
+BUILT_MODULE_NAME[0]="madifx"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms/"
+
+AUTOINSTALL="yes"


### PR DESCRIPTION
This adds auto-build with DKMS.

If you follow:
```
sudo ln -s $(pwd) /usr/src/alsa-madifx-0.0
sudo dkms build alsa-madifx/0.0
sudo dkms install alsa-madifx/0.0
```
It will build and install. Should survive kernel updates like that unless there are significant ABI changes.